### PR TITLE
Add nodeSelector option

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nfs-webmin
-version: 0.1.0
+version: 0.1.2
 description: NFS Server + Webmin (admin UI)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nfs-webmin
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nfs-webmin)](https://artifacthub.io/packages/search?repo=nfs-webmin)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nfs-webmin)](https://artifacthub.io/packages/search?repo=nfs-webmin)
 
 NFS Server + Webmin (admin UI)
 
@@ -12,6 +12,7 @@ NFS Server + Webmin (admin UI)
 | nfs.image | string | `"itsthenetwork/nfs-server-alpine:latest"` |  |
 | nfs.sharedDirectory | string | `"/data"` |  |
 | resources | object | `{}` |  |
+| nodeSelector | object | `{}` | Node selector labels |
 | webmin.image | string | `"sameersbn/webmin:latest"` |  |
 | webmin.rootPassword | string | `"secret"` |  |
 

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: nfs-webmin
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: nfs
           image: {{ .Values.nfs.image }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,3 +8,4 @@ webmin:
   rootPassword: secret
 
 resources: {}
+nodeSelector: {}


### PR DESCRIPTION
## Summary
- replace `nodeName` with a `nodeSelector` map
- bump chart version to 0.1.2 and document the new option

## Testing
- `helm lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb5c2e7b88320850ff7ac43e1d1d9

## Summary by Sourcery

Add a configurable nodeSelector map to the StatefulSet spec, bump the chart version to 0.1.2, and document the new nodeSelector option

New Features:
- Introduce a nodeSelector value to enable custom pod scheduling

Enhancements:
- Update Helm chart version to 0.1.2

Documentation:
- Add nodeSelector to the values table and update version badge in README