### PR TITLE
Add dynamic names and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 NFS Server + Webmin (admin UI)
 
+This chart generates resource names and labels dynamically using the Helm release
+name. Labels follow the `app.kubernetes.io/*` conventions similar to Bitnami
+charts.
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Common helm helper templates
+*/}}
+{{- define "nfs-webmin.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "nfs-webmin.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "nfs-webmin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "nfs-webmin.labels" -}}
+helm.sh/chart: {{ include "nfs-webmin.chart" . }}
+{{ include "nfs-webmin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "nfs-webmin.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nfs-webmin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -5,12 +5,19 @@ Common helm helper templates
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- /*
+"nfs-webmin.fullname" helper
+Accepts an optional suffix argument.
+Usage: {{ include "nfs-webmin.fullname" (dict "context" . "suffix" "-nfs") }}
+*/ -}}
 {{- define "nfs-webmin.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $ctx := .context | default . -}}
+{{- $suffix := .suffix | default "" -}}
+{{- if $ctx.Values.fullnameOverride -}}
+{{- printf "%s%s" $ctx.Values.fullnameOverride $suffix | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default $ctx.Chart.Name $ctx.Values.nameOverride -}}
+{{- printf "%s-%s%s" $ctx.Release.Name $name $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/service-nfs.yaml
+++ b/templates/service-nfs.yaml
@@ -1,10 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nfs-service
+  name: {{ include "nfs-webmin.fullname" . }}-nfs
+  labels:
+    {{- include "nfs-webmin.labels" . | nindent 4 }}
 spec:
   selector:
-    app: nfs-webmin
+    {{- include "nfs-webmin.selectorLabels" . | nindent 4 }}
   ports:
     - name: nfs
       port: 2049

--- a/templates/service-webmin.yaml
+++ b/templates/service-webmin.yaml
@@ -1,10 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: webmin-service
+  name: {{ include "nfs-webmin.fullname" . }}-webmin
+  labels:
+    {{- include "nfs-webmin.labels" . | nindent 4 }}
 spec:
   selector:
-    app: nfs-webmin
+    {{- include "nfs-webmin.selectorLabels" . | nindent 4 }}
   ports:
     - name: webmin
       port: 10000

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -1,17 +1,19 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: nfs-webmin
+  name: {{ include "nfs-webmin.fullname" . }}
+  labels:
+    {{- include "nfs-webmin.labels" . | nindent 4 }}
 spec:
-  serviceName: nfs-webmin
+  serviceName: {{ include "nfs-webmin.fullname" . }}
   replicas: 1
   selector:
     matchLabels:
-      app: nfs-webmin
+      {{- include "nfs-webmin.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: nfs-webmin
+        {{- include "nfs-webmin.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary
- implement typical Helm helpers for dynamic naming
- use the helpers in all templates
- document dynamic naming in the README

## Testing
- `helm lint .`

------
https://chatgpt.com/codex/tasks/task_e_6860248720dc83209b1df1541112119e

## Summary by Sourcery

Add and integrate Helm helper functions to generate dynamic names, labels, and selectors across all templates and document the usage in the README.

New Features:
- Introduce Helm helper templates for dynamic resource naming and labeling

Enhancements:
- Refactor Service and StatefulSet manifests to use dynamic name, selector, and label helpers

Documentation:
- Add README section explaining dynamic naming and standard Kubernetes label conventions