### PR TITLE
Fix duplicated NFS prefix

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -17,11 +17,11 @@ Usage: {{ include "nfs-webmin.fullname" (dict "context" . "suffix" "-nfs") }}
 {{- printf "%s%s" $ctx.Values.fullnameOverride $suffix | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default $ctx.Chart.Name $ctx.Values.nameOverride -}}
-{{- if and (eq $ctx.Release.Name "nfs") (hasPrefix "nfs-" $name) -}}
-{{- printf "%s%s" $name $suffix | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s%s" $ctx.Release.Name $name $suffix | trunc 63 | trimSuffix "-" -}}
+{{- $fullname := printf "%s-%s%s" $ctx.Release.Name $name $suffix -}}
+{{- if eq $ctx.Release.Name "nfs" -}}
+{{- $fullname = trimPrefix "nfs-" $fullname -}}
 {{- end -}}
+{{- $fullname | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -17,7 +17,11 @@ Usage: {{ include "nfs-webmin.fullname" (dict "context" . "suffix" "-nfs") }}
 {{- printf "%s%s" $ctx.Values.fullnameOverride $suffix | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default $ctx.Chart.Name $ctx.Values.nameOverride -}}
+{{- if and (eq $ctx.Release.Name "nfs") (hasPrefix "nfs-" $name) -}}
+{{- printf "%s%s" $name $suffix | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s%s" $ctx.Release.Name $name $suffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## Summary
- avoid duplication of the `nfs` prefix when the release is also named `nfs`

## Testing
- `helm lint .`
- `helm template nfs .`
- `helm template myrelease .`

------
https://chatgpt.com/codex/tasks/task_e_686050496e90832082090a073c0d303e

## Summary by Sourcery

Bug Fixes:
- Avoid duplicating the `nfs` prefix when the release is named `nfs` and the chart name already starts with `nfs-`.