### PR TITLE
Configure Webmin to keep only NFS export module

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -38,6 +38,15 @@ spec:
           env:
             - name: ROOT_PASSWORD
               value: {{ .Values.webmin.rootPassword }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    cd /usr/share/webmin
+                    ls | grep -v exports | xargs -I{} mv {} {}.disabled
           ports:
             - containerPort: 10000
           volumeMounts:


### PR DESCRIPTION
## Summary
- add lifecycle postStart hook to webmin container so only the NFS exports module remains enabled

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68606af9f2a483208adc601bc8359dda