### PR TITLE
Add container enable toggles

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nfs-webmin
-version: 0.2.0
+version: 0.2.1
 description: NFS Server + Webmin (admin UI)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nfs-webmin
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nfs-webmin)](https://artifacthub.io/packages/search?repo=nfs-webmin)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nfs-webmin)](https://artifacthub.io/packages/search?repo=nfs-webmin)
 
 NFS Server + Webmin (admin UI)
 
@@ -27,13 +27,15 @@ webmin:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| nfs.enabled | bool | `true` | Enable NFS container |
 | nfs.hostDataPath | string | `"/mnt/nfs-test"` |  |
-| nfs.image | string | `"itsthenetwork/nfs-server-alpine"` |  |
+| nfs.image | string | `"jgrojasx/webmin"` |  |
 | nfs.tag | string | `"latest"` |  |
 | nfs.sharedDirectory | string | `"/data"` |  |
+| webmin.enabled | bool | `true` | Enable Webmin container |
+| webmin.image | string | `"rook/nfs"` |  |
+| webmin.tag | string | `"v1.7.3-4.gf94ea44"` |  |
+| webmin.rootPassword | string | `"secret"` |  |
 | resources | object | `{}` |  |
 | nodeSelector | object | `{}` | Node selector labels |
-| webmin.image | string | `"sameersbn/webmin"` |  |
-| webmin.tag | string | `"latest"` |  |
-| webmin.rootPassword | string | `"secret"` |  |
 

--- a/templates/service-nfs.yaml
+++ b/templates/service-nfs.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nfs.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
       port: 111
       targetPort: 111
   type: NodePort   # Для удобного теста на minikube/kind/standalone
+{{- end }}

--- a/templates/service-webmin.yaml
+++ b/templates/service-webmin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webmin.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
       port: 10000
       targetPort: 10000
   type: NodePort
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       containers:
+        {{- if .Values.nfs.enabled }}
         - name: nfs
           image: {{ printf "%s:%s" .Values.nfs.image (.Values.nfs.tag | default "latest") }}
           securityContext:
@@ -33,6 +34,8 @@ spec:
           volumeMounts:
             - name: nfs-data
               mountPath: {{ .Values.nfs.sharedDirectory }}
+        {{- end }}
+        {{- if .Values.webmin.enabled }}
         - name: webmin
           image: {{ printf "%s:%s" .Values.webmin.image (.Values.webmin.tag | default "latest") }}
           env:
@@ -52,6 +55,7 @@ spec:
           volumeMounts:
             - name: nfs-data
               mountPath: {{ .Values.nfs.sharedDirectory }}
+        {{- end }}
       volumes:
         - name: nfs-data
           hostPath:

--- a/values.yaml
+++ b/values.yaml
@@ -1,10 +1,12 @@
 nfs:
+  enabled: true
   image: jgrojasx/webmin
   tag: latest
   sharedDirectory: /data
   hostDataPath: /mnt/nfs-test
 
 webmin:
+  enabled: true
   image: rook/nfs
   tag: v1.7.3-4.gf94ea44
   rootPassword: secret


### PR DESCRIPTION
## Summary
- allow disabling nfs and webmin containers
- wrap services in enabled checks
- document new options
- bump chart version to 0.2.1

## Testing
- `helm lint .`

------
https://chatgpt.com/codex/tasks/task_e_68611c584d548320bd4687a74b5ae669

## Summary by Sourcery

Add ability to enable or disable NFS and Webmin containers via new chart values, wrap their Service and StatefulSet resources in conditional checks, update documentation for the new options, and bump chart version to 0.2.1

New Features:
- Introduce nfs.enabled and webmin.enabled toggles to conditionally deploy containers

Enhancements:
- Wrap NFS and Webmin Service and StatefulSet definitions in conditional if blocks based on their enabled flags

Build:
- Bump Helm chart version to 0.2.1

Documentation:
- Document the new enable toggles and default values in README