### PR TITLE
Enable extra environment variables

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nfs-webmin
-version: 0.2.1
+version: 0.2.2
 description: NFS Server + Webmin (admin UI)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nfs-webmin
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nfs-webmin)](https://artifacthub.io/packages/search?repo=nfs-webmin)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nfs-webmin)](https://artifacthub.io/packages/search?repo=nfs-webmin)
 
 NFS Server + Webmin (admin UI)
 
@@ -32,10 +32,12 @@ webmin:
 | nfs.image | string | `"jgrojasx/webmin"` |  |
 | nfs.tag | string | `"latest"` |  |
 | nfs.sharedDirectory | string | `"/data"` |  |
+| nfs.extraEnvVars | list | `[]` | Additional environment variables for the NFS container |
 | webmin.enabled | bool | `true` | Enable Webmin container |
 | webmin.image | string | `"rook/nfs"` |  |
 | webmin.tag | string | `"v1.7.3-4.gf94ea44"` |  |
 | webmin.rootPassword | string | `"secret"` |  |
+| webmin.extraEnvVars | list | `[]` | Additional environment variables for the Webmin container |
 | resources | object | `{}` |  |
 | nodeSelector | object | `{}` | Node selector labels |
 

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -28,6 +28,9 @@ spec:
           env:
             - name: SHARED_DIRECTORY
               value: {{ .Values.nfs.sharedDirectory }}
+            {{- with .Values.nfs.extraEnvVars }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
           ports:
             - containerPort: 2049
             - containerPort: 111
@@ -41,6 +44,9 @@ spec:
           env:
             - name: ROOT_PASSWORD
               value: {{ .Values.webmin.rootPassword }}
+            {{- with .Values.webmin.extraEnvVars }}
+            {{ toYaml . | indent 12 }}
+            {{- end }}
           lifecycle:
             postStart:
               exec:

--- a/values.yaml
+++ b/values.yaml
@@ -4,12 +4,14 @@ nfs:
   tag: latest
   sharedDirectory: /data
   hostDataPath: /mnt/nfs-test
+  extraEnvVars: []
 
 webmin:
   enabled: true
   image: rook/nfs
   tag: v1.7.3-4.gf94ea44
   rootPassword: secret
+  extraEnvVars: []
 
 resources: {}
 nodeSelector: {}


### PR DESCRIPTION
## Summary
- add `extraEnvVars` sections for NFS and Webmin containers
- bump chart version to 0.2.2 and update docs

## Testing
- `helm lint .`

------
https://chatgpt.com/codex/tasks/task_e_686128320644832098737a544d3b089a

## Summary by Sourcery

Enable passing additional environment variables to both NFS and Webmin containers, update default values, bump chart version, and refresh documentation

New Features:
- Add `extraEnvVars` support for NFS and Webmin containers

Enhancements:
- Bump Helm chart version to 0.2.2

Documentation:
- Document `extraEnvVars` parameters in README and update version badge